### PR TITLE
fix problem with multiline strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-to-dart",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "description": "generate dart json_serializable classes using graphql-code-generator",
   "files": [
     "dist"

--- a/src/helpers/multiline-comment.js
+++ b/src/helpers/multiline-comment.js
@@ -2,8 +2,17 @@ const linewrap = require('linewrap')
 const { SafeString } = require('handlebars')
 const wrap = linewrap(80, {
   wrapLineIndent: 0,
-  lineBreak: '\n/// '
+  lineBreak: '\n'
 })
+
+function safeDartCommentLineWrapped(comment) {
+    return comment
+        .split('\n')
+        .flatMap((value) => wrap(value).split('\n'))
+        .map((value)=> `/// ${value}`)
+        .join('\n')
+}
+
 export default function multilineComment (comment = '') {
-  return new SafeString(`/// ${wrap(comment)}`)
+  return new SafeString(safeDartCommentLineWrapped(comment))
 }


### PR DESCRIPTION
Hi, 

these small changes fix the problem of invalid code generated if comments are used with multiple lines, for example:
```graphql
type Foo {
  # Examples
  # * null
  # * or something else
  bar: String!
}

```

