### PR TITLE
don't use required fields for magic types

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "graphql-to-dart",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "generate dart json_serializable classes using graphql-code-generator",
   "files": [
     "dist"

--- a/src/helpers/resolve-type.js
+++ b/src/helpers/resolve-type.js
@@ -17,9 +17,12 @@ const primitives = {
   DateTime: "DateTime"
 };
 
-function jsonKey({ type, required = false, addSerializers = false }) {
+function jsonKey({ type, className, required = false, addSerializers = false }) {
   if (!required && !addSerializers) {
     return "";
+  }
+  if(["Query", "Mutation", "Subscription"].indexOf(className) > -1 ){
+    required = false;
   }
   return (
     "@JsonKey(" +
@@ -50,7 +53,8 @@ export default function resolveType(
   replace = {},
   isArray,
   irreducibles = [],
-  rawTypeText
+  rawTypeText,
+  className
 ) {
   let isRequired = false;
   let addSerializers = true;
@@ -75,6 +79,7 @@ export default function resolveType(
       return new SafeString(
         jsonKey({
           type: fieldType,
+          className: className,
           required: isRequired,
           addSerializers
         }) + wrap(isArray, fieldType)
@@ -84,7 +89,7 @@ export default function resolveType(
     }
   }
   return new SafeString(
-    jsonKey({ type: fieldType, required: isRequired }) +
+    jsonKey({ type: fieldType, required: isRequired, className: className }) +
       wrap(isArray, fieldType)
   );
 }

--- a/src/templates/defineClass.handlebars
+++ b/src/templates/defineClass.handlebars
@@ -26,7 +26,7 @@ class {{ className }} {{
       isArray
       @root.config.irreducibleTypes
       raw
-      typeName
+      ../className
   }} {{name}};
   {{~/if}}{{/if}}{{/each}}
 
@@ -82,6 +82,7 @@ class {{ className }} {{
                 isArray
                 @root.config.irreducibleTypes
                 raw
+                ../className
             }} {{name}},
         {{~/if}}{{/if}}{{/each}}
     }


### PR DESCRIPTION
We accoutered another problem with the dart types. Consider the following graphql definition:

```graphql
type Query {
  getFoo(id: String!): String
  getBar(id: String!): String
}
```

The generated code will be:

``` dart
class Query {
     @JsonKey(required: true, disallowNullValue: true,)
    String getFoo;

     @JsonKey(required: true, disallowNullValue: true,)
    String getBar;

....

}
```

The required JsonKeys are a problem in this case because we query `getFoo` XOR `getBar`, so the  `fromJSON` will throw an error.

My workaround is just to make all fields in the types  `Query`, `Mutation` and `Subscription` non required. 




