### PR TITLE
Fix camelCase mismatch

### DIFF
--- a/src/templates/documents/selectionSetClass.handlebars
+++ b/src/templates/documents/selectionSetClass.handlebars
@@ -53,9 +53,9 @@ class {{ className }} {{
     Set<String> missingFields = Set();
     {{#each allFields}}
     {{~#if isRequired}}
-    if ({{ dartName name }} == null){
+    if ({{ camelCase (dartName name) }} == null){
       missingFields.add("
-      {{~ dartName name ~}}
+      {{~ camelCase (dartName name) ~}}
       {{~#if isAliased}} aliased from {{ dartName schemaFieldName }}
       {{~/if~}}
       ");


### PR DESCRIPTION
I had a field that begun with a capital, however in selectionSet.handlebars it uses camelCase on the set and get but not on the missingRequiredFields